### PR TITLE
Für Print-Version: Schnittmarken

### DIFF
--- a/fibel.tex
+++ b/fibel.tex
@@ -18,7 +18,7 @@
 %	showframe
 ]{scrartcl}
 
-\def\fibelcropmarks{false}
+\def\fibelcropmarks{true}
 
 \input{tex/01_PaketeEinstellungen.tex}
 


### PR DESCRIPTION
Hiermit werden die Schnittmarken und Anschnitt aktiviert, was dafür sorgt, dass die Druckerei weiß, wo sie zuschneiden kann, und Dinge, die bis zum Rand gehen sollen, von der Druckerei auch richtig gedruckt werden.